### PR TITLE
Install `elm` binary, too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-vendor/elm-*
+vendor/elm*

--- a/bin/elm
+++ b/bin/elm
@@ -2,7 +2,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var bin = require('../')['elm-reactor'];
+var bin = require('../').elm;
 var input = process.argv.slice(2);
 
 spawn(bin, input, {stdio: 'inherit'})

--- a/bin/elm-doc
+++ b/bin/elm-doc
@@ -2,7 +2,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var bin = require('../').doc;
+var bin = require('../')['elm-doc'];
 var input = process.argv.slice(2);
 
 spawn(bin, input, {stdio: 'inherit'})

--- a/bin/elm-make
+++ b/bin/elm-make
@@ -2,7 +2,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var bin = require('../').make;
+var bin = require('../')['elm-make'];
 var input = process.argv.slice(2);
 
 spawn(bin, input, {stdio: 'inherit'})

--- a/bin/elm-package
+++ b/bin/elm-package
@@ -2,7 +2,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var bin = require('../').package;
+var bin = require('../')['elm-package'];
 var input = process.argv.slice(2);
 
 spawn(bin, input, {stdio: 'inherit'})

--- a/bin/elm-repl
+++ b/bin/elm-repl
@@ -2,7 +2,7 @@
 'use strict';
 
 var spawn = require('child_process').spawn;
-var bin = require('../').repl;
+var bin = require('../')['elm-repl'];
 var input = process.argv.slice(2);
 
 spawn(bin, input, {stdio: 'inherit'})

--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 'use strict';
 
 [
-	'doc',
-	'make',
-	'package',
-	'reactor',
-	'repl'
+	'elm',
+	'elm-doc',
+	'elm-make',
+	'elm-package',
+	'elm-reactor',
+	'elm-repl'
 ].forEach(function (bin) {
 	module.exports[bin] = require('./lib')(bin).path();
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,7 @@ var BASE_URL = [
 ].join('');
 
 module.exports = function (name) {
-	name = process.platform === 'win32' ? 'elm-' + name + '.exe' : 'elm-' + name;
+	name = process.platform === 'win32' ? name + '.exe' : name;
 
 	return new BinWrapper()
 		.src(BASE_URL + 'osx/elm-platform-osx.tar.gz', 'darwin')

--- a/lib/install.js
+++ b/lib/install.js
@@ -4,11 +4,12 @@ var asyncEachSeries = require('async-each-series');
 var log = require('logalot');
 
 var bins = [
-	'doc',
-	'make',
-	'package',
-	'reactor',
-	'repl'
+	'elm',
+	'elm-doc',
+	'elm-make',
+	'elm-package',
+	'elm-reactor',
+	'elm-repl'
 ];
 
 asyncEachSeries(bins, function (name, next) {
@@ -17,12 +18,12 @@ asyncEachSeries(bins, function (name, next) {
 	bin.run(['--help'], function (err) {
 		if (err) {
 			log.error(err.message);
-			log.error('elm-' + name + ' pre-build test failed');
+			log.error(name + ' pre-build test failed');
 			next();
 			return;
 		}
 
-		log.success('elm-' + name + ' pre-build test passed successfully');
+		log.success(name + ' pre-build test passed successfully');
 		next();
 	});
 }, log.write.bind(log));

--- a/test.js
+++ b/test.js
@@ -9,11 +9,12 @@ test('return path to binaries and verify that they are working', function (t) {
 	t.plan(10);
 
 	var bins = [
-		'doc',
-		'make',
-		'package',
-		'reactor',
-		'repl'
+		'elm',
+		'elm-doc',
+		'elm-make',
+		'elm-package',
+		'elm-reactor',
+		'elm-repl'
 	];
 
 	asyncEachSeries(bins, function (bin, next) {


### PR DESCRIPTION
Fixes #11

This is a breaking change as it updates all exported symbols. I removed
the `elm-` prefixing magic as it would have been cumbersome to handle
the unprefixed `elm` special case.

Luckily, the `elm` binary is already included in the vendor packages.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/kevva/elm-bin/12)
<!-- Reviewable:end -->
