### PR TITLE
add link to get-started-page

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,8 @@ $ elm-repl --help
 
 Also, set the `ELM_HOME` environment variable to `/usr/local/lib/node_modules/elm/share` or the corresponding directory created on your machine.
 
+Then, check out http://elm-lang.org/Get-Started.elm.
+
 ## License
 
 MIT © [Kevin Mårtensson](https://github.com/kevva)


### PR DESCRIPTION
The Windows and Mac installers of Elm provide that link at the end of the installation process, so I guess it makes sense to also mention it to people using the npm installer.