### PR TITLE
Add an empty SIGINT handler

### DIFF
--- a/bin/elm-repl
+++ b/bin/elm-repl
@@ -5,5 +5,7 @@ var spawn = require('child_process').spawn;
 var bin = require('../')['elm-repl'];
 var input = process.argv.slice(2);
 
+process.on('SIGINT', function () { });
+
 spawn(bin, input, {stdio: 'inherit'})
 	.on('exit', process.exit);

--- a/bin/elm-repl
+++ b/bin/elm-repl
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn;
 var bin = require('../')['elm-repl'];
 var input = process.argv.slice(2);
 
-process.on('SIGINT', function () { });
+process.on('SIGINT', function () {});
 
 spawn(bin, input, {stdio: 'inherit'})
 	.on('exit', process.exit);


### PR DESCRIPTION
On elm-repl, Ctrl + C aborts just the current computation, not the entire session. (https://github.com/elm-lang/elm-repl/commit/aa274b78ca6b658c61b32e24573239b128b19949)
but node wrapper aborts its session on SIGINT while its child process doesn't, which reads to the error message.

```
elm-repl: <stdin>: hGetChar: hardware fault (Input/output error) 
```

Adding an empty SIGINT handler to wrapper can prevent it. (
